### PR TITLE
Add site footer with copyright line

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -16,6 +16,9 @@
       <a href="{{ '/' | relative_url }}" class="text-sm text-gray-500 hover:text-gray-900">{{ site.title }}</a>
     </header>
     {{ content }}
+    <footer class="mt-16 text-sm text-gray-500">
+      &copy; {{ site.time | date: "%Y" }} Guided Rails, LLC. All rights reserved.
+    </footer>
   </main>
 </body>
 </html>


### PR DESCRIPTION
Adds a footer to the default layout so it renders on every page (home and posts). Shows a copyright line with the year derived from `site.time`, styled with the same muted-gray Tailwind utilities as the header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
