### PR TITLE
Meet AAA color contrast for muted text

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,10 +13,10 @@
 <body class="bg-white text-gray-900 antialiased">
   <main class="max-w-2xl mx-auto px-6 py-16">
     <header class="mb-16">
-      <a href="{{ '/' | relative_url }}" class="text-sm text-gray-500 hover:text-gray-900">{{ site.title }}</a>
+      <a href="{{ '/' | relative_url }}" class="text-sm text-gray-600 hover:text-gray-900">{{ site.title }}</a>
     </header>
     {{ content }}
-    <footer class="mt-16 text-sm text-gray-500">
+    <footer class="mt-16 text-sm text-gray-600">
       &copy; {{ site.time | date: "%Y" }} Guided Rails, LLC. All rights reserved.
     </footer>
   </main>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -13,7 +13,7 @@ layout: default
       <li>
         <a href="{{ post.url | relative_url }}" class="block group">
           <h2 class="text-lg font-medium group-hover:underline">{{ post.title }}</h2>
-          <time datetime="{{ post.date | date_to_xmlschema }}" class="text-sm text-gray-500">
+          <time datetime="{{ post.date | date_to_xmlschema }}" class="text-sm text-gray-600">
             {{ post.date | date: "%B %-d, %Y" }}
           </time>
         </a>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 
 <article>
   <h1 class="text-3xl font-semibold tracking-tight">{{ page.title }}</h1>
-  <time datetime="{{ page.date | date_to_xmlschema }}" class="block mt-2 text-sm text-gray-500">
+  <time datetime="{{ page.date | date_to_xmlschema }}" class="block mt-2 text-sm text-gray-600">
     {{ page.date | date: "%B %-d, %Y" }}
   </time>
   <div class="prose mt-8 max-w-none">


### PR DESCRIPTION
## What

Bumps the site's muted text from `text-gray-500` to `text-gray-600` so every text element meets **WCAG 2.2 AAA** color contrast.

## Why

`text-gray-500` (#6b7280) on white is ~4.83:1 — it passes AA but fails AAA, which requires **7:1** for normal-size text. An axe (axe-core 4.10.3) scan with WCAG 2.2 AAA flagged three elements:

- the "Guided Rails" header home link
- the post date / home-page post-list dates
- the footer copyright line

`text-gray-600` (#4b5563) is ~7.56:1, clearing AAA while keeping the same muted look the home-page tagline already uses (it was already `gray-600`).

## Changes

- `_layouts/default.html` — header home link + footer
- `_layouts/post.html` — post date
- `_layouts/home.html` — post-list dates

## Verification

axe re-scan drops from 3 contrast issues to 0. No `text-gray-500` remains in any source or built file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
